### PR TITLE
Remove <Provider />, add preload() function

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,8 @@
     "version": "0.1",
     "words": [
         "cawfree",
+        "deduped",
+        "preload",
         "transpiled"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -74,16 +74,12 @@ Finally, let's render our `<App />`! For the purpose of this tutorial, let's ass
 import * as React from 'react';
 import { createWormhole } from 'react-native-wormhole';
 
-const { Provider, Wormhole } = createWormhole({
+const { Wormhole } = createWormhole({
   verify: async () => true,
 });
 
 export default function App() {
-  return (
-    <Provider>
-      <Wormhole source={{ uri: 'https://cawfree.com/MyNewWormhole.jsx' }} />
-    </Provider>
-  );
+  return <Wormhole source={{ uri: 'https://cawfree.com/MyNewWormhole.jsx' }} />;
 }
 ```
 
@@ -96,7 +92,7 @@ And that's everything! Once our component has finished downloading, it'll be mou
 By default, a `Wormhole` is only capable of consuming global functionality from two different modules; [`react`](https://github.com/facebook/react) and [`react-native`](https://github.com/facebook/react-native), meaning that only "vanilla" React Native functionality is available. However, it is possible to introduce support for additional modules. In the snippet below, we show how to allow a `Wormhole` to render a [`WebView`](https://github.com/react-native-webview/react-native-webview):
 
 ```diff
-const { Provider, Wormhole } = createWormhole({
+const { Wormhole } = createWormhole({
 +  global: {
 +    require: (moduleId: string) => {
 +      if (moduleId === 'react') {
@@ -129,7 +125,7 @@ This property is used to determine the integrity of a response, and is responsib
 + import { ethers } from 'ethers';
 + import { SIGNER_ADDRESS, PORT } from '@env';
 
-const { Provider, Wormhole } = createWormhole({
+const { Wormhole } = createWormhole({
 +  verify: async ({ headers, data }: AxiosResponse) => {
 +    const signature = headers['x-csrf-token'];
 +    const bytes = ethers.utils.arrayify(signature);

--- a/README.md
+++ b/README.md
@@ -143,5 +143,23 @@ In this implementation, the server is expected to return a HTTP response header 
 
 If the recovered address is not trusted, the script **will not be executed**.
 
+#### 🏎️ Preloading
+
+Making a call to `createWormhole()` also returns a `preload` function which can be used to asynchronously cache remote JSX before a `Wormhole` has been mounted:
+
+```typescript
+const { preload } = createWormhole({ verify: async () => true });
+
+(async () => {
+  try {
+    await preload('https://cawfree.com/MyNewWormhole.jsx');
+  } catch (e) {
+    console.error('Failed to preload.');
+  }
+})();
+```
+
+Wormholes dependent upon the external content will subsequently render immediately if the operation has completed in time. Meanwhile, concurrent requests to the same resource will be deduped.
+
 ### ✌️ License
 [**MIT**](./LICENSE)

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,7 +7,7 @@ import { SIGNER_ADDRESS, PORT } from '@env';
 
 import type { AxiosResponse } from 'axios';
 
-const { Provider, Wormhole } = createWormhole({
+const { Wormhole } = createWormhole({
   verify: async ({ headers, data }: AxiosResponse) => {
     const signature = headers['x-csrf-token'];
     const bytes = ethers.utils.arrayify(signature);
@@ -22,11 +22,9 @@ const { Provider, Wormhole } = createWormhole({
 
 export default function App() {
   return (
-    <Provider>
-      <Wormhole
-        source={{ uri: `http://${localhost}:${PORT}/__mocks__/Mock_1.jsx` }}
-        renderError={({ error }) => console.error(error) || null}
-      />
-    </Provider>
+    <Wormhole
+      onError={console.error}
+      source={{ uri: `http://${localhost}:${PORT}/__mocks__/Mock_1.jsx` }}
+    />
   );
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -23,7 +23,6 @@ const { Wormhole } = createWormhole({
 export default function App() {
   return (
     <Wormhole
-      onError={console.error}
       source={{ uri: `http://${localhost}:${PORT}/__mocks__/Mock_1.jsx` }}
     />
   );

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "react-native-localhost": "^1.0.0",
     "react-native-screens": "~2.15.0",
     "react-native-web": "~0.13.12",
-    "react-native-wormhole": "^0.1.0-alpha.0"
+    "react-native-wormhole": "0.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.10",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6102,10 +6102,8 @@ react-native-web@~0.13.12:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
-react-native-wormhole@^0.1.0-alpha.0:
+react-native-wormhole@../:
   version "0.1.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/react-native-wormhole/-/react-native-wormhole-0.1.0-alpha.0.tgz#537213f0f16775def8773d8f7ddc75c975a68009"
-  integrity sha512-kQuaGued2E4c2MfFIXVdr5OSq3E5/pLEZQbrwI/RsjaVI9V7BgMBxFn4p8awZ/EkYUiP6+B08tyJezZxnOYOKQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
     axios "^0.21.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-wormhole",
-  "version": "0.1.0-alpha.0",
+  "version": "0.2.0",
   "description": "⚛️  🌌 Inter-dimensional Portals for React Native. 👽 🖖",
   "main": "dist",
   "scripts": {

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -25,4 +25,5 @@ export type WormholeContextValue = WormholeContextConfig & {
     options: WormholeOptions,
   ) => Promise<React.Component>;
   readonly buildRequestForUri: (config: AxiosRequestConfig) => AxiosPromise<string>;
+  readonly onError: (error: Error) => void;
 };

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,29 +1,28 @@
 import { AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
 
+export type PromiseCallback<T> = {
+  readonly resolve: (result: T) => void;
+  readonly reject: (error: Error) => void;
+};
+
 export type WormholeSource = {
   readonly uri: string;
 } | string;
 
-export type WormholeOptions = {
-  readonly dangerouslySetInnerJSX: boolean;
+export type WormholeComponentCache = {
+  readonly [uri: string]: React.Component | null;
 };
 
-export type PromiseCallback<T> = {
-  readonly resolve: (result: T) => void;
-  readonly reject: (error: Error) => void;
+export type WormholeTasks = {
+  readonly [uri: string]: PromiseCallback<React.Component>[];
+};
+
+export type WormholeOptions = {
+  readonly dangerouslySetInnerJSX: boolean;
 };
 
 export type WormholeContextConfig = {
   readonly verify: (response: AxiosResponse<string>) => Promise<boolean>;
   readonly buildRequestForUri?: (config: AxiosRequestConfig) => AxiosPromise<string>;
   readonly global?: any;
-};
-
-export type WormholeContextValue = WormholeContextConfig & {
-  readonly open: (
-    uri: WormholeSource,
-    options: WormholeOptions,
-  ) => Promise<React.Component>;
-  readonly buildRequestForUri: (config: AxiosRequestConfig) => AxiosPromise<string>;
-  readonly onError: (error: Error) => void;
 };

--- a/src/components/Wormhole.tsx
+++ b/src/components/Wormhole.tsx
@@ -21,7 +21,7 @@ export default function Wormhole({
   ...extras
 }: WormholeProps): JSX.Element {
   // @ts-ignore
-  const { open } = useWormhole();
+  const { open, onError } = useWormhole();
   const { forceUpdate } = useForceUpdate();
   const [Component, setComponent] = React.useState<React.Component | null>(null);
   const [error, setError] = React.useState<Error | null>(null);
@@ -33,10 +33,19 @@ export default function Wormhole({
       } catch (e) {
         setComponent(() => null);
         setError(e);
+        onError(e);
         return forceUpdate();
       }
     })();
-  }, [open, source, setComponent, forceUpdate, setError, dangerouslySetInnerJSX]);
+  }, [
+    open,
+    source,
+    setComponent,
+    forceUpdate,
+    setError,
+    dangerouslySetInnerJSX,
+    onError,
+  ]);
   const FallbackComponent = React.useCallback((): JSX.Element => {
     return renderError({ error: new Error('[Wormhole]: Failed to render.') });
   }, [renderError]);

--- a/src/components/Wormhole.tsx
+++ b/src/components/Wormhole.tsx
@@ -1,35 +1,45 @@
 import * as React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import { WormholeContextValue, WormholeSource } from '../@types';
+import { WormholeOptions, WormholeSource } from '../@types';
 import { useForceUpdate } from '../hooks';
 
 export type WormholeProps = {
   readonly source: WormholeSource;
-  readonly useWormhole?: () => WormholeContextValue;
   readonly renderLoading?: () => JSX.Element;
   readonly renderError?: (props: { readonly error: Error }) => JSX.Element;
   readonly dangerouslySetInnerJSX?: boolean;
+  readonly onError?: (error: Error) => void;
+  readonly shouldOpenWormhole?: (
+    source: WormholeSource,
+    options: WormholeOptions
+  ) => Promise<React.Component>;
 };
 
 export default function Wormhole({
   source,
-  useWormhole,
   renderLoading = () => <React.Fragment />,
   renderError = () => <React.Fragment />,
   dangerouslySetInnerJSX = false,
+  onError = console.error,
+  shouldOpenWormhole,
   ...extras
 }: WormholeProps): JSX.Element {
-  // @ts-ignore
-  const { open, onError } = useWormhole();
   const { forceUpdate } = useForceUpdate();
   const [Component, setComponent] = React.useState<React.Component | null>(null);
   const [error, setError] = React.useState<Error | null>(null);
   React.useEffect(() => {
     (async () => {
       try {
-        const Component = await open(source, { dangerouslySetInnerJSX });
-        return setComponent(() => Component);
+        if (typeof shouldOpenWormhole === 'function') {
+          const Component = await shouldOpenWormhole(source, { dangerouslySetInnerJSX });
+          return setComponent(() => Component);
+        }
+        throw new Error(
+          `[Wormhole]: Expected function shouldOpenWormhole, encountered ${
+            typeof shouldOpenWormhole
+          }.`
+        );
       } catch (e) {
         setComponent(() => null);
         setError(e);
@@ -38,7 +48,7 @@ export default function Wormhole({
       }
     })();
   }, [
-    open,
+    shouldOpenWormhole,
     source,
     setComponent,
     forceUpdate,

--- a/src/constants/createWormhole.tsx
+++ b/src/constants/createWormhole.tsx
@@ -207,7 +207,12 @@ export default function createWormhole({
     <BaseWormhole {...props} shouldOpenWormhole={shouldOpenWormhole} />
   );
 
+  const preload = async (uri: string): Promise<void> => {
+    await shouldOpenWormhole({ uri }, { dangerouslySetInnerJSX: false })
+  };
+
   return Object.freeze({
     Wormhole,
+    preload,
   });
 }

--- a/src/constants/createWormhole.tsx
+++ b/src/constants/createWormhole.tsx
@@ -13,6 +13,7 @@ import { Wormhole as BaseWormhole } from '../components';
 import { WormholeProps } from '../components/Wormhole';
 
 export type WormholeProviderProps = {
+  readonly onError?: (error: Error) => void;
   readonly children?: JSX.Element | readonly JSX.Element[] | string;
 };
 
@@ -23,6 +24,7 @@ function createProvider(
 ) {
   return function WormholeProvider({
     children,
+    onError = console.error,
   }: WormholeProviderProps): JSX.Element {
     const cache = React.useMemo<{
       readonly [uri: string]: React.Component | null;
@@ -141,8 +143,8 @@ function createProvider(
       [openUri, openString],
     );
     const value = React.useMemo(
-      () => ({ ...baseContext, open }),
-      [baseContext, open],
+      () => ({ ...baseContext, open, onError }),
+      [baseContext, open, onError],
     );
     return (
       <Context.Provider value={value}>
@@ -180,6 +182,7 @@ export default function createWormhole({
     open: () => Promise.reject(
       new Error('[Wormhole]: It looks like you\'ve forgotten to declare a Wormhole Provider.')
     ),
+    onError: console.error,
   });
   const Context = React.createContext<WormholeContextValue>(
     defaultValue

--- a/src/constants/createWormhole.tsx
+++ b/src/constants/createWormhole.tsx
@@ -1,173 +1,174 @@
 import * as React from 'react';
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import {
   PromiseCallback,
   WormholeContextConfig,
-  WormholeContextValue,
   WormholeSource,
   WormholeOptions,
+  WormholeComponentCache,
+  WormholeTasks,
 } from '../@types';
 
 import { Wormhole as BaseWormhole } from '../components';
 import { WormholeProps } from '../components/Wormhole';
 
-export type WormholeProviderProps = {
-  readonly onError?: (error: Error) => void;
-  readonly children?: JSX.Element | readonly JSX.Element[] | string;
-};
-
 const globalName = '__WORMHOLE__';
 
-function createProvider(
-  Context: React.Context<WormholeContextValue>
-) {
-  return function WormholeProvider({
-    children,
-    onError = console.error,
-  }: WormholeProviderProps): JSX.Element {
-    const cache = React.useMemo<{
-      readonly [uri: string]: React.Component | null;
-    }>(() => ({}), []);
-    const tasks = React.useMemo<{
-      readonly [uri: string]: PromiseCallback<React.Component>[];
-    }>(() => ({}), []);
-    const baseContext = React.useContext(Context);
-    const { verify, global, buildRequestForUri } = baseContext;
-    const shouldComplete = React.useCallback(
-      (uri: string, error?: Error) => {
-        const { [uri]: maybeComponent } = cache;
-        const { [uri]: callbacks } = tasks;
-        Object.assign(tasks, { [uri]: null });
-        callbacks.forEach(({ resolve, reject }) => {
-          if (!!maybeComponent) {
-            return resolve(maybeComponent);
-          }
-          return reject(
-            error || new Error(`[Wormhole]: Failed to allocate for uri "${uri}".`)
-          );
-        });
-      },
-      [cache, tasks],
-    );
-    const shouldCreateComponent = React.useCallback(async (src: string) => {
-      const Component = await new Function(
-        globalName,
-        `${Object.keys(global).map((key) => `var ${key} = ${globalName}.${key};`).join('\n')}; const exports = {}; ${src}; return exports.default;`
-      )(global);
-      if (typeof Component !== 'function') {
-        throw new Error(
-          `[Wormhole]: Expected function, encountered ${typeof Component}. Did you forget to mark your Wormhole as a default export?`
-        );
-      }
-      return Component;
-    }, [global]);
-    const shouldOpen = React.useCallback(async (uri: string) => {
-      try {
-        const result = await buildRequestForUri({
-          url: uri,
-          method: 'get',
-        });
-        const { data } = result;
-        if (typeof data !== 'string') {
-          throw new Error(`[Wormhole]: Expected string data, encountered ${typeof data}.`);
-        }
-        if (!await verify(result)) {
-          throw new Error(`[Wormhole]: Failed to verify "${uri}".`);
-        }
-        const Component = await shouldCreateComponent(data);
-        Object.assign(cache, { [uri]: Component });
-        return shouldComplete(uri);
-      } catch (e) {
-        Object.assign(cache, { [uri]: null });
-        if (typeof e === 'string') {
-          return shouldComplete(uri, new Error(e));
-        } else if (typeof e.message === 'string') {
-          return shouldComplete(uri, new Error(`${e.message}`));
-        }
-        return shouldComplete(uri, e);
-      }
-    }, [
-      verify,
-      shouldCreateComponent,
-      cache,
-      tasks,
-      shouldComplete,
-      buildRequestForUri,
-    ]);
-    const openUri = React.useCallback(
-      async (uri: string, callback: PromiseCallback<React.Component>) => {
-        const { [uri]: Component } = cache;
-        const { reject } = callback;
-        if (Component === null) {
-          return reject(
-            new Error(`[Wormhole]: Component at uri "${uri}" could not be instantiated.`)
-          );
-        } else if (typeof Component === 'function') {
-          return Component;
-        }
+const defaultGlobal = Object.freeze({
+  require: (moduleId: string) => {
+    if (moduleId === 'react') {
+      // @ts-ignore
+      return require('react');
+    } else if (moduleId === 'react-native') {
+      // @ts-ignore
+      return require('react-native');
+    }
+    return null;
+  },
+});
 
-        const { [uri]: queue } = tasks;
-        if (Array.isArray(queue)) {
-          return queue.push(callback);
-        }
+const buildCompletionHandler = (
+  cache: WormholeComponentCache,
+  tasks: WormholeTasks,
+) => (uri: string, error?: Error): void => {
+  const { [uri]: maybeComponent } = cache;
+  const { [uri]: callbacks } = tasks;
+  Object.assign(tasks, { [uri]: null });
+  callbacks.forEach(({ resolve, reject }) => {
+    if (!!maybeComponent) {
+      return resolve(maybeComponent);
+    }
+    return reject(
+      error || new Error(`[Wormhole]: Failed to allocate for uri "${uri}".`)
+    );
+  });
+};
 
-        Object.assign(tasks, { [uri]: [callback] });
-        return shouldOpen(uri);
-      },
-      [cache, tasks, shouldOpen]
-    );
-    const openString = React.useCallback(async (src: string) => {
-      return shouldCreateComponent(src);
-    }, [shouldCreateComponent]);
-    const open = React.useCallback(
-      async (source: WormholeSource, options: WormholeOptions) => {
-        const { dangerouslySetInnerJSX } = options;
-        if (typeof source === 'string') {
-          if (dangerouslySetInnerJSX === true) {
-            return openString(source as string);
-          }
-          throw new Error(
-            `[Wormhole]: Attempted to instantiate a Wormhole using a string, but dangerouslySetInnerJSX was not true.`
-          );
-        } else if (source && typeof source === 'object') {
-          const { uri } = source;
-          if (typeof uri === 'string') {
-            return new Promise<React.Component>(
-              (resolve, reject) => openUri(uri, { resolve, reject }),
-            );
-          }
-        }
-        throw new Error(`[Wormhole]: Expected valid source, encountered ${typeof source}.`);
-      },
-      [openUri, openString],
-    );
-    const value = React.useMemo(
-      () => ({ ...baseContext, open, onError }),
-      [baseContext, open, onError],
-    );
-    return (
-      <Context.Provider value={value}>
-        {children}
-      </Context.Provider>
+const buildCreateComponent = (
+  global: any
+) => async (src: string): Promise<React.Component> => {
+  const Component = await new Function(
+    globalName,
+    `${Object.keys(global).map((key) => `var ${key} = ${globalName}.${key};`).join('\n')}; const exports = {}; ${src}; return exports.default;`
+  )(global);
+  if (typeof Component !== 'function') {
+    throw new Error(
+      `[Wormhole]: Expected function, encountered ${typeof Component}. Did you forget to mark your Wormhole as a default export?`
     );
   }
-}
+  return Component;
+};
+
+const buildRequestOpenUri = ({
+  cache,
+  buildRequestForUri,
+  verify,
+  shouldCreateComponent,
+  shouldComplete,
+}: {
+  readonly cache: WormholeComponentCache,
+  readonly buildRequestForUri: (config: AxiosRequestConfig) => AxiosPromise<string>;
+  readonly verify: (response: AxiosResponse<string>) => Promise<boolean>;
+  readonly shouldCreateComponent: (src: string) => Promise<React.Component>;
+  readonly shouldComplete: (uri: string, error?: Error) => void;
+}) => async (uri: string) => {
+  try {
+    const result = await buildRequestForUri({
+      url: uri,
+      method: 'get',
+    });
+    const { data } = result;
+    if (typeof data !== 'string') {
+      throw new Error(`[Wormhole]: Expected string data, encountered ${typeof data}.`);
+    }
+    if (await verify(result) !== true) {
+      throw new Error(`[Wormhole]: Failed to verify "${uri}".`);
+    }
+    const Component = await shouldCreateComponent(data);
+    Object.assign(cache, { [uri]: Component });
+    return shouldComplete(uri);
+  } catch (e) {
+    Object.assign(cache, { [uri]: null });
+    if (typeof e === 'string') {
+      return shouldComplete(uri, new Error(e));
+    } else if (typeof e.message === 'string') {
+      return shouldComplete(uri, new Error(`${e.message}`));
+    }
+    return shouldComplete(uri, e);
+  }
+};
+
+const buildOpenUri = ({
+  cache,
+  tasks,
+  shouldRequestOpenUri,
+}: {
+  readonly cache: WormholeComponentCache;
+  readonly tasks: WormholeTasks;
+  readonly shouldRequestOpenUri: (uri: string) => void;
+}) => (uri: string, callback: PromiseCallback<React.Component>): void => {
+  const { [uri]: Component } = cache;
+  const { resolve, reject } = callback;
+  if (Component === null) {
+    return reject(
+      new Error(`[Wormhole]: Component at uri "${uri}" could not be instantiated.`)
+    );
+  } else if (typeof Component === 'function') {
+    return resolve(Component);
+  }
+
+  const { [uri]: queue } = tasks;
+  if (Array.isArray(queue)) {
+    queue.push(callback);
+    return;
+  }
+
+  Object.assign(tasks, { [uri]: [callback] });
+
+  return shouldRequestOpenUri(uri);
+};
+
+const buildOpenString = ({
+  shouldCreateComponent,
+}: {
+  readonly shouldCreateComponent: (src: string) => Promise<React.Component>;
+}) => async (src: string) => {
+  return shouldCreateComponent(src);
+};
+
+const buildOpenWormhole = ({
+  shouldOpenString,
+  shouldOpenUri,
+}: {
+  readonly shouldOpenString: (src: string) => Promise<React.Component>;
+  readonly shouldOpenUri: (
+    uri: string,
+    callback: PromiseCallback<React.Component>
+  ) => void;
+}) => async (source: WormholeSource, options: WormholeOptions): Promise<React.Component> => {
+  const { dangerouslySetInnerJSX } = options;
+  if (typeof source === 'string') {
+    if (dangerouslySetInnerJSX === true) {
+      return shouldOpenString(source as string);
+    }
+    throw new Error(
+      `[Wormhole]: Attempted to instantiate a Wormhole using a string, but dangerouslySetInnerJSX was not true.`
+    );
+  } else if (source && typeof source === 'object') {
+    const { uri } = source;
+    if (typeof uri === 'string') {
+      return new Promise<React.Component>(
+        (resolve, reject) => shouldOpenUri(uri, { resolve, reject }),
+      );
+    }
+  }
+  throw new Error(`[Wormhole]: Expected valid source, encountered ${typeof source}.`);
+};
 
 export default function createWormhole({
   buildRequestForUri = (config: AxiosRequestConfig) => axios(config),
-  global = {
-    require: (moduleId: string) => {
-      if (moduleId === 'react') {
-        // @ts-ignore
-        return require('react');
-      } else if (moduleId === 'react-native') {
-        // @ts-ignore
-        return require('react-native');
-      }
-      return null;
-    },
-  },
+  global = defaultGlobal,
   verify,
 }: WormholeContextConfig) {
   if (typeof verify !== 'function') {
@@ -175,24 +176,38 @@ export default function createWormhole({
       '[Wormhole]: To create a Wormhole, you **must** pass a verify() function.',
     );
   }
-  const defaultValue: WormholeContextValue = Object.freeze({
+
+  const cache: WormholeComponentCache = {};
+  const tasks: WormholeTasks = {};
+
+  const shouldComplete = buildCompletionHandler(cache, tasks);
+  const shouldCreateComponent = buildCreateComponent(global);
+  const shouldRequestOpenUri = buildRequestOpenUri({
+    cache,
     buildRequestForUri,
-    global,
     verify,
-    open: () => Promise.reject(
-      new Error('[Wormhole]: It looks like you\'ve forgotten to declare a Wormhole Provider.')
-    ),
-    onError: console.error,
+    shouldCreateComponent,
+    shouldComplete,
   });
-  const Context = React.createContext<WormholeContextValue>(
-    defaultValue
-  );
-  const useWormhole = () => React.useContext(Context);
+  const shouldOpenUri = buildOpenUri({
+    cache,
+    tasks,
+    shouldRequestOpenUri,
+  });
+  const shouldOpenString = buildOpenString({
+    shouldCreateComponent,
+  });
+
+  const shouldOpenWormhole = buildOpenWormhole({
+    shouldOpenUri,
+    shouldOpenString,
+  });
+
   const Wormhole = (props: WormholeProps) => (
-    <BaseWormhole {...props} useWormhole={useWormhole} />
+    <BaseWormhole {...props} shouldOpenWormhole={shouldOpenWormhole} />
   );
+
   return Object.freeze({
-    Provider: createProvider(Context),
     Wormhole,
   });
 }


### PR DESCRIPTION
The `Provider` didn't add much to the functionality of `react-native-wormhole` since most of the download logic is stateless and can be embedded within a call to `createWormhole`. Additionally, by extracting this logic we were able to expose a `preload()` function to improve performance.